### PR TITLE
Fix a miscompile: backwards liveness analysis was missing some blocks in functions with infinite loops.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot</artifactId>
   
   <name>Soot</name>
-  <version>2017-01-29-cfallin</version>
+  <version>2017-07-20-cfallin</version>
   <description>A Java Optimization Framework</description>
   
   <properties>


### PR DESCRIPTION
Soot's backend performs register coloring (`soot.toolkits.scalar.FastColorer`) using a liveness analysis that is implemented in the usual style as a backwards dataflow analysis. Unfortunately, this analysis has a simplistic notion of graph entry points when performing the workqueue loop:

* If the graph has return statements, these are the (backwards) entry points.
* Otherwise, find all gotos and start there.

The former is incorrect in a critical case observed in our `misc.raytracer` benchmark: when a function has one path that falls into an infinite loop with no return, and another path that returns normally, the above logic results in a backwards analysis that completely skips the infinite loop. This resulted in the backend falsely believing that no variables were live inside the infinite loop, so two variables aliased onto a single color (JVM bytecode local).

To fix this issue, this PR adds some logic to `GraphView.BACKWARD.getEntries()` that, starting from ordinary entry points (return statements), traverses backward (via predecessors) and finds the transitively-reachable blocks. When the workqueue becomes empty, it traverses all nodes in the graph exhaustively; as soon as it sees one that has not yet been reached, it continues at that node, traversing its predecessors again. In this way, if there is an SCC of nodes unreachable backwards from a return (e.g., a large infinite loop with some control flow), we should only have to add one node in that loop to include the whole loop in the analysis.

Tested with `misc.raytracer`.